### PR TITLE
Tag backend

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -4,10 +4,12 @@ import { useUserStore } from "@/stores/user";
 import { storeToRefs } from "pinia";
 import { computed, onBeforeMount } from "vue";
 import { RouterLink, RouterView, useRoute } from "vue-router";
+import { useTagStore } from "./stores/tags";
 
 const currentRoute = useRoute();
 const currentRouteName = computed(() => currentRoute.name);
 const userStore = useUserStore();
+const tagStore = useTagStore();
 const { isLoggedIn } = storeToRefs(userStore);
 const { toast } = storeToRefs(useToastStore());
 
@@ -15,6 +17,7 @@ const { toast } = storeToRefs(useToastStore());
 onBeforeMount(async () => {
   try {
     await userStore.updateSession();
+    await tagStore.getLanguageTags();
   } catch {
     // User is not logged in
   }

--- a/client/components/TranslationRequest/TranslationRequestForm.vue
+++ b/client/components/TranslationRequest/TranslationRequestForm.vue
@@ -4,7 +4,7 @@ import { ref } from "vue";
 import { useTagStore } from "../../stores/tags";
 import { fetchy } from "../../utils/fetchy";
 const tagStore = useTagStore();
-const { languageTags, contentTags } = storeToRefs(useTagStore());
+const { languageTags } = storeToRefs(useTagStore());
 
 const DOMAINS = ["Computer Science", "Biology"];
 const LANGUAGES = languageTags;

--- a/client/components/TranslationRequest/TranslationRequestForm.vue
+++ b/client/components/TranslationRequest/TranslationRequestForm.vue
@@ -33,16 +33,25 @@ function deleteAuthor(idx: number) {
   authors.value.splice(idx, 1);
 }
 
+function clearForm() {
+  formOpen.value = false;
+  title.value = "";
+  authors.value = [{ first: "", last: "" }];
+  year.value = undefined;
+  domain.value = "";
+  content.value = "";
+  originalLanguage.value = "";
+}
+
 async function submitRequest() {
   if (isFormValid.value) {
-    console.log(originalLanguage.value[0].toUpperCase() + originalLanguage.value.slice(1));
     try {
       await fetchy("/api/document", "POST", {
         body: {
           title: title.value,
           authors: authors.value,
           year: Number.parseInt(year.value),
-          domain: domain.value,
+          domain: domain.value[0].toUpperCase() + domain.value.slice(1),
           content: content.value,
           originalLanguage: originalLanguage.value[0].toUpperCase() + originalLanguage.value.slice(1),
         },
@@ -54,7 +63,7 @@ async function submitRequest() {
     }
   }
 
-  // formOpen.value = false;
+  clearForm();
 }
 
 const domainRule = [
@@ -113,7 +122,7 @@ const closeForm = () => {
             <v-text-field label="Document Title" v-model="title" :rules="nonEmptyRule"></v-text-field>
             <v-row>
               <v-col :sm="4"><v-text-field label="Year Published" v-model="year" :rules="yearRules"></v-text-field></v-col>
-              <v-col :sm="4"><v-select label="Domain" v-model="domain" :items="DOMAINS" :rules="domainRule"></v-select></v-col>
+              <v-col :sm="4"><v-combobox label="Domain" v-model="domain" :items="DOMAINS" :rules="domainRule"></v-combobox></v-col>
               <v-col :sm="4"><v-combobox label="Language" v-model="originalLanguage" :items="LANGUAGES" :rules="domainRule"></v-combobox></v-col>
             </v-row>
 

--- a/client/components/TranslationRequest/TranslationRequestForm.vue
+++ b/client/components/TranslationRequest/TranslationRequestForm.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+import { storeToRefs } from "pinia";
 import { ref } from "vue";
+import { useTagStore } from "../../stores/tags";
 import { fetchy } from "../../utils/fetchy";
+const tagStore = useTagStore();
+const { languageTags, contentTags } = storeToRefs(useTagStore());
 
 const DOMAINS = ["Computer Science", "Biology"];
-const LANGUAGES = ["English", "Turkish"];
+const LANGUAGES = languageTags;
 
 // keeps track of if form is open or not
 const formOpen = ref(false);
@@ -31,6 +35,7 @@ function deleteAuthor(idx: number) {
 
 async function submitRequest() {
   if (isFormValid.value) {
+    console.log(originalLanguage.value[0].toUpperCase() + originalLanguage.value.slice(1));
     try {
       await fetchy("/api/document", "POST", {
         body: {
@@ -39,16 +44,17 @@ async function submitRequest() {
           year: Number.parseInt(year.value),
           domain: domain.value,
           content: content.value,
-          originalLanguage: originalLanguage.value,
+          originalLanguage: originalLanguage.value[0].toUpperCase() + originalLanguage.value.slice(1),
         },
       });
+      await tagStore.getLanguageTags();
       emit("refreshDocuments");
     } catch (e) {
       return;
     }
   }
 
-  formOpen.value = false;
+  // formOpen.value = false;
 }
 
 const domainRule = [
@@ -71,7 +77,6 @@ const yearRules = [
     return "Field cannot be empty.";
   },
   (v: string) => {
-    console.log("v ", v);
     const validYear = new RegExp("^[0-9]{4}$");
     if (validYear.test(v)) return true;
     return "Must be a valid year";
@@ -109,7 +114,7 @@ const closeForm = () => {
             <v-row>
               <v-col :sm="4"><v-text-field label="Year Published" v-model="year" :rules="yearRules"></v-text-field></v-col>
               <v-col :sm="4"><v-select label="Domain" v-model="domain" :items="DOMAINS" :rules="domainRule"></v-select></v-col>
-              <v-col :sm="4"><v-select label="Language" v-model="originalLanguage" :items="LANGUAGES" :rules="domainRule"></v-select></v-col>
+              <v-col :sm="4"><v-combobox label="Language" v-model="originalLanguage" :items="LANGUAGES" :rules="domainRule"></v-combobox></v-col>
             </v-row>
 
             <v-row>

--- a/client/components/TranslationRequest/TranslationRequestPreview.vue
+++ b/client/components/TranslationRequest/TranslationRequestPreview.vue
@@ -27,6 +27,7 @@ const props = defineProps(["document"]);
     </p>
 
     <p>{{ `Published ${props.document.year}` }}</p>
+    <p>{{ props.document.originalLanguage }}</p>
     <p>{{ props.document.domain }}</p>
   </div>
 </template>

--- a/client/stores/tags.ts
+++ b/client/stores/tags.ts
@@ -1,0 +1,20 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import { Tag } from "../types";
+import { fetchy } from "../utils/fetchy";
+
+export const useTagStore = defineStore(
+  "tag",
+  () => {
+    const languageTags = ref([]);
+    const contentTags = ref([]);
+
+    const getLanguageTags = async () => {
+      const languageTagDocs = await fetchy(`/api/tag/language`, "GET");
+      languageTags.value = languageTagDocs.map((t: Tag) => t.name);
+    };
+
+    return { languageTags, contentTags, getLanguageTags };
+  },
+  { persist: true },
+);

--- a/client/stores/tags.ts
+++ b/client/stores/tags.ts
@@ -7,14 +7,13 @@ export const useTagStore = defineStore(
   "tag",
   () => {
     const languageTags = ref([]);
-    const contentTags = ref([]);
 
     const getLanguageTags = async () => {
       const languageTagDocs = await fetchy(`/api/tag/language`, "GET");
       languageTags.value = languageTagDocs.map((t: Tag) => t.name);
     };
 
-    return { languageTags, contentTags, getLanguageTags };
+    return { languageTags, getLanguageTags };
   },
   { persist: true },
 );

--- a/client/types.d.ts
+++ b/client/types.d.ts
@@ -2,3 +2,8 @@ export interface Author {
   first: string;
   last: string;
 }
+
+export interface Tag {
+  name: string;
+  isLanguage: boolean;
+}

--- a/server/concepts/tag.ts
+++ b/server/concepts/tag.ts
@@ -23,8 +23,13 @@ export default class TagConcept {
     const tagId = await this.tags.createOne({ name, isLanguage });
     return { msg: "Created tag!", tagId: tagId };
   }
-  async getTags(query: Partial<TagDoc>) {
-    return await this.tags.readMany(query);
+
+  async getTag(_id: ObjectId) {
+    return await this.tags.readOne({ _id });
+  }
+
+  async getTags() {
+    return await this.tags.readMany({});
   }
   async getLanguageTags() {
     return await this.tags.readMany({ isLanguage: true });

--- a/server/concepts/tag.ts
+++ b/server/concepts/tag.ts
@@ -23,8 +23,8 @@ export default class TagConcept {
     const tagId = await this.tags.createOne({ name, isLanguage });
     return { msg: "Created tag!", tagId: tagId };
   }
-  async getTags() {
-    return await this.tags.readMany({});
+  async getTags(query: Partial<TagDoc>) {
+    return await this.tags.readMany(query);
   }
   async getLanguageTags() {
     return await this.tags.readMany({ isLanguage: true });
@@ -37,8 +37,8 @@ export default class TagConcept {
     return tagDoc.isLanguage;
   }
 
-  async getTagId(name: string) {
-    const tagDoc = await this.tags.readOne({ name });
+  async getTagId(name: string, isLanguage: boolean) {
+    const tagDoc = await this.tags.readOne({ name, isLanguage });
     if (tagDoc === null) {
       throw new Error(`Tag ${name} not found!`);
     }

--- a/server/responses.ts
+++ b/server/responses.ts
@@ -1,24 +1,24 @@
-import { TagDoc } from "./concepts/tag";
+import { Tag } from "./app";
+import { DocumentDoc } from "./concepts/document";
 
 /**
  * This class does useful conversions for the frontend.
  * For example, it converts a {@link PostDoc} into a more readable format for the frontend.
  */
 export default class Responses {
-  /**
-   * Convert TagDoc into more readable format for the frontend by only returning the name of the tag.
-   */
-  static tag(tag: TagDoc) {
-    if (!tag) {
-      return tag;
-    }
-    return { name: tag.name };
+  /** convert DocumentDoc to readable format by converting tags from ObjectId to name representation */
+
+  static async document(document: DocumentDoc) {
+    const languageTag = await Tag.getTag(document.originalLanguage);
+    const domainTag = await Tag.getTag(document.domain);
+    return { ...document, originalLanguage: languageTag?.name, domain: domainTag?.name };
   }
 
-  /**
-   * Converts array of TagDoc into more readable format for the frontend by only returning the name of the tag.
-   */
-  static tags(tags: Array<TagDoc>) {
-    return tags.map((t) => this.tag(t));
+  static async documents(documents: DocumentDoc[]) {
+    console.log("HERE");
+    const promises = documents.map(async (d) => {
+      return await this.document(d);
+    });
+    return await Promise.all(promises);
   }
 }

--- a/server/responses.ts
+++ b/server/responses.ts
@@ -1,5 +1,24 @@
+import { TagDoc } from "./concepts/tag";
+
 /**
  * This class does useful conversions for the frontend.
  * For example, it converts a {@link PostDoc} into a more readable format for the frontend.
  */
-export default class Responses {}
+export default class Responses {
+  /**
+   * Convert TagDoc into more readable format for the frontend by only returning the name of the tag.
+   */
+  static tag(tag: TagDoc) {
+    if (!tag) {
+      return tag;
+    }
+    return { name: tag.name };
+  }
+
+  /**
+   * Converts array of TagDoc into more readable format for the frontend by only returning the name of the tag.
+   */
+  static tags(tags: Array<TagDoc>) {
+    return tags.map((t) => this.tag(t));
+  }
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,10 +1,10 @@
 import { ObjectId } from "mongodb";
 import { Document, Section, SectionTranslation, Tag, User, WebSession } from "./app";
 import { Author } from "./concepts/document";
-import { TagDoc } from "./concepts/tag";
 import { UserDoc } from "./concepts/user";
 import { WebSessionDoc } from "./concepts/websession";
 import { Router, getExpressRouter } from "./framework/router";
+import Responses from "./responses";
 class Routes {
   @Router.get("/session")
   async getSessionUser(session: WebSessionDoc) {
@@ -66,8 +66,8 @@ class Routes {
     return await Tag.attachTag(new ObjectId(tag), new ObjectId(attachedTo));
   }
   @Router.get("/tag")
-  async getTags(query: Partial<TagDoc>) {
-    return await Tag.getTags(query);
+  async getTags() {
+    return await Tag.getTags();
   }
   @Router.get("/tag/language")
   async getLanguageTags() {
@@ -111,11 +111,11 @@ class Routes {
   }
   @Router.get("/document")
   async getDocuments() {
-    return await Document.getDocuments();
+    return await Responses.documents(await Document.getDocuments());
   }
   @Router.get("/document/:id")
   async getDocument(id: string) {
-    return await Document.getDocument(new ObjectId(id));
+    return await Responses.document(await Document.getDocument(new ObjectId(id)));
   }
   @Router.delete("/document/:id")
   async deleteDocument(session: WebSessionDoc, id: string) {


### PR DESCRIPTION
This PR:

- Reformats DocumentDoc so that the originalLanguage and domains fields return names of the tags instead of the ObjectID
- Sets up global store to handle tags
- Reworks FE of TranslationRequestForm so that domain and language inputs can take in custom tags
- Reworks BE so that tags that don't exist are created